### PR TITLE
Fixed a critical bug/vulnerability in ObliviousTransfer/HashRandomOracle

### DIFF
--- a/CompactMPC/ObliviousTransfer/HashRandomOracle.cs
+++ b/CompactMPC/ObliviousTransfer/HashRandomOracle.cs
@@ -21,7 +21,7 @@ namespace CompactMPC.ObliviousTransfer
             _hashAlgorithm = hashAlgorithm;
             _hashAlgorithmLock = new object();
         }
-        
+
         public override IEnumerable<byte> Invoke(byte[] query)
         {
             byte[] seed;
@@ -38,6 +38,9 @@ namespace CompactMPC.ObliviousTransfer
                 {
                     stream.Write(seed, 0, seed.Length);
                     stream.Write(BitConverter.GetBytes(counter), 0, 4);
+                    // note(lumip): seek to beginning of the stream! otherwise, ComputeHash will start at the end and compute the
+                    //  hash over the empty word no matter what query/seed is given!
+                    stream.Seek(0, SeekOrigin.Begin);
 
                     lock (_hashAlgorithmLock)
                     {

--- a/UnitTests/ObliviousTransfer/HashRandomOracleTest.cs
+++ b/UnitTests/ObliviousTransfer/HashRandomOracleTest.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Text;
+using System.Linq;
+using System.Collections;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+
+namespace CompactMPC.ObliviousTransfer.UnitTests
+{
+    [TestClass]
+    public class HashRandomOracleTest
+    {
+        [TestMethod]
+        public void TestInvoke()
+        {
+            using (CryptoContext cryptoContext = CryptoContext.CreateDefault())
+            {
+                RandomOracle oracle = new HashRandomOracle(cryptoContext.HashAlgorithm);
+
+                byte[] query1Bytes = { 235, 12, 13, 72, 138, 13, 62, 13, 39, 147, 198, 173, 23, 87, 27, 99 };
+                byte[] query2Bytes = { 84, 23, 123, 85, 62, 28, 54, 98, 187, 238, 18, 5, 78, 1, 78, 243 };
+
+                byte[] response1 = oracle.Invoke(query1Bytes).Take(10).ToArray();
+                byte[] response2 = oracle.Invoke(query2Bytes).Take(10).ToArray();
+                CollectionAssert.AreNotEqual(response1, response2);
+            }
+        }
+    }
+}

--- a/UnitTests/ObliviousTransfer/RandomOracleTest.cs
+++ b/UnitTests/ObliviousTransfer/RandomOracleTest.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Text;
+using System.Linq;
+using System.Collections;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+
+namespace CompactMPC.ObliviousTransfer.UnitTests
+{
+    internal class RandomOracleStub : RandomOracle
+    {
+        private Dictionary<byte[], byte[]> _valueDict;
+
+        public RandomOracleStub(Dictionary<byte[], byte[]> valueDict)
+        {
+            _valueDict = new Dictionary<byte[], byte[]>(valueDict);
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// <exception cref="KeyNotFoundException">If the query is not found in the value dictionary passed into the constructor.</exception>
+        /// </remarks>
+        public override IEnumerable<byte> Invoke(byte[] query)
+        {
+            return _valueDict[query];
+        }
+    }
+
+    [TestClass]
+    public class RandomOracleTest
+    {
+        [TestMethod]
+        public void TestStub()
+        {
+            Dictionary<byte[], byte[]> keyValuePairs = new Dictionary<byte[], byte[]>();
+            keyValuePairs[BitArray.FromBinaryString("1001").ToBytes()] = BitArray.FromBinaryString("100101011100101").ToBytes();
+            keyValuePairs[BitArray.FromBinaryString("1010").ToBytes()] = BitArray.FromBinaryString("101011110101100").ToBytes();
+
+            RandomOracle oracle = new RandomOracleStub(keyValuePairs);
+            foreach (KeyValuePair<byte[], byte[]> pair in keyValuePairs)
+            {
+                Assert.AreEqual(pair.Value, oracle.Invoke(pair.Key));
+            }
+        }
+
+        [TestMethod]
+        public void TestMask()
+        {
+            var query1 = BitArray.FromBinaryString("1001");
+            var query2 = BitArray.FromBinaryString("1010");
+            byte[] query1Bytes = query1.ToBytes();
+            byte[] query2Bytes = query2.ToBytes();
+
+            var value1 = BitArray.FromBinaryString("1001010111001011");
+            var value2 = BitArray.FromBinaryString("1010111101011001");
+
+            Dictionary<byte[], byte[]> keyValuePairs = new Dictionary<byte[], byte[]>();
+            keyValuePairs[query1Bytes] = value1.ToBytes();
+            keyValuePairs[query2Bytes] = value2.ToBytes();
+
+            RandomOracle oracle = new RandomOracleStub(keyValuePairs);
+
+            var message1 = BitArray.FromBinaryString("0000000000000000");
+            var message2 = BitArray.FromBinaryString("1100110011001100");
+            byte[] message1Bytes = message1.ToBytes();
+            byte[] message2Bytes = message2.ToBytes();
+
+            byte[] masked11 = oracle.Mask(message1Bytes, query1Bytes);
+            byte[] masked12 = oracle.Mask(message1Bytes, query2Bytes);
+            CollectionAssert.AreEqual(keyValuePairs[query1Bytes], masked11);
+            CollectionAssert.AreEqual(keyValuePairs[query2Bytes], masked12);
+
+
+            byte[] masked21 = oracle.Mask(message2Bytes, query1Bytes);
+            byte[] masked22 = oracle.Mask(message2Bytes, query2Bytes);
+
+            BitArray expected12 = BitArray.FromBytes(keyValuePairs[query2Bytes], 16);
+            expected12.Xor(message1);
+            BitArray expected22 = BitArray.FromBytes(keyValuePairs[query2Bytes], 16);
+            expected22.Xor(message2);
+
+            CollectionAssert.AreEqual(expected12.ToBytes(), masked12);
+            CollectionAssert.AreEqual(expected22.ToBytes(), masked22);
+        }
+    }
+}


### PR DESCRIPTION
After filling the buffer stream over which the hash would be computed to generate randomized output bytes, the stream cursor was not moved to the beginning, causing the hash to be always computed over the empty word, thus giving a constant output no matter the seed / supplied query value.

Detected while working on OTs: This meant that the receiver could trivially uncover all masked options sent by the server (and all previous calculation according to the Naor-Pinkas Protocol were for naught).