### PR TITLE
Improved OT performance

### DIFF
--- a/CompactMPC/ObliviousTransfer/NaorPinkasObliviousTransfer.cs
+++ b/CompactMPC/ObliviousTransfer/NaorPinkasObliviousTransfer.cs
@@ -64,14 +64,16 @@ namespace CompactMPC.ObliviousTransfer
             BigInteger alpha;
             listOfCs[0] = GenerateGroupElement(out alpha);
             listOfExpCs[0] = listOfCs[0];
-            
-            Parallel.For(1, 4, i =>
-            {
-                BigInteger exponent;
-                listOfCs[i] = GenerateGroupElement(out exponent);
-                listOfExpCs[i] = BigInteger.ModPow(listOfCs[i], alpha, _parameters.P);
-            });
 
+            do
+            {
+                Parallel.For(1, 4, i =>
+                {
+                    BigInteger exponent;
+                    listOfCs[i] = GenerateGroupElement(out exponent);
+                    listOfExpCs[i] = BigInteger.ModPow(listOfCs[i], alpha, _parameters.P);
+                });
+            } while (listOfCs.Distinct().Count() != listOfCs.Count()); // ensuring that all values are unique!
 
 #if DEBUG
             stopwatch.Stop();

--- a/CompactMPC/ObliviousTransfer/NaorPinkasObliviousTransfer.cs
+++ b/CompactMPC/ObliviousTransfer/NaorPinkasObliviousTransfer.cs
@@ -14,6 +14,11 @@ using CompactMPC.Buffers;
 
 namespace CompactMPC.ObliviousTransfer
 {
+    /// <summary>
+    /// 1-out-of-4 Oblivious Transfer Implementation following a protocol by Naor and Pinkas.
+    /// </summary>
+    /// 
+    /// Reference: Moni Naor and Benny Pinkas: Efficient oblivious transfer protocols 2001. https://dl.acm.org/citation.cfm?id=365502
     public class NaorPinkasObliviousTransfer : GeneralizedObliviousTransfer
     {
         private SecurityParameters _parameters;
@@ -54,16 +59,19 @@ namespace CompactMPC.ObliviousTransfer
 #endif
             
             Quadruple<BigInteger> listOfCs = new Quadruple<BigInteger>();
-            Quadruple<BigInteger> listOfExponents = new Quadruple<BigInteger>();
+            Quadruple<BigInteger> listOfExpCs = new Quadruple<BigInteger>();
+
+            BigInteger alpha;
+            listOfCs[0] = GenerateGroupElement(out alpha);
+            listOfExpCs[0] = listOfCs[0];
             
-            Parallel.For(0, 4, i =>
+            Parallel.For(1, 4, i =>
             {
                 BigInteger exponent;
                 listOfCs[i] = GenerateGroupElement(out exponent);
-                listOfExponents[i] = exponent;
+                listOfExpCs[i] = BigInteger.ModPow(listOfCs[i], alpha, _parameters.P);
             });
 
-            BigInteger alpha = listOfExponents[0];
 
 #if DEBUG
             stopwatch.Stop();
@@ -91,14 +99,32 @@ namespace CompactMPC.ObliviousTransfer
             Parallel.For(0, numberOfInvocations, j =>
             {
                 maskedOptions[j] = new Quadruple<byte[]>();
+                BigInteger baseExpD = BigInteger.ModPow(listOfDs[j], alpha, _parameters.P);
+                BigInteger invBaseExpD = Invert(baseExpD);
+
                 Parallel.For(0, 4, i =>
                 {
-                    BigInteger baseD = listOfDs[j];
-                    if (i > 0)
-                        baseD = listOfCs[i] * Invert(baseD);
+                    BigInteger expD;
+                    if (i == 0)
+                    {
+                        expD = baseExpD;
+                    }
+                    else
+                    {
+                        expD = (listOfExpCs[i] * invBaseExpD) % _parameters.P;
+                    }
 
-                    BigInteger e = BigInteger.ModPow(baseD, alpha, _parameters.P);
-                    maskedOptions[j][i] = MaskOption(options[j][i], e, j, i);
+                    // note(lumip): the protocol as proposed by Naor and Pinkas includes a random value
+                    //  to be incorporated in the random oracle query to ensure that the same query does
+                    //  not occur several times. This is partly because the envision several receivers
+                    //  over which the same Cs are used. Since we are having seperate sets of Cs for each
+                    //  sender-receiver pair, the requirement of unique queries is satisified just using
+                    //  the index j of the OT invocation and we can save a bit of bandwidth.
+
+                    // todo: think about whether we want to use a static set of Cs for each sender for all
+                    //  connection to reduce the required amount of computation per OT. Would require to
+                    //  maintain state in this class and negate the points made in the note above.
+                    maskedOptions[j][i] = MaskOption(options[j][i], expD, j, i);
                 });
             });
 
@@ -177,6 +203,9 @@ namespace CompactMPC.ObliviousTransfer
 
         private BigInteger GenerateGroupElement(out BigInteger exponent)
         {
+            // note(lumip): do not give in to the temptation of replacing the exponent > _parameters.Q part with a
+            //  modulo operation, as that would case the exponent to be no longer uniformly sampled (which could
+            //  have an impact on security)
             do
             {
                 exponent = _randomNumberGenerator.GetBigInteger(_parameters.ExponentSize);
@@ -246,10 +275,22 @@ namespace CompactMPC.ObliviousTransfer
             return options;
         }
 
-        private byte[] MaskOption(byte[] message, BigInteger groupElement,  int invocationIndex, int optionIndex)
+        /// <summary>
+        /// Masks an option (i.e., a sender input message).
+        /// </summary>
+        /// 
+        /// The option is XOR-masked with the output of a random oracle queried with the
+        /// concatentation of the binary representations of the given groupElement, invocationIndex and optionIndex.
+        /// 
+        /// <param name="option">The sender input/option to be masked.</param>
+        /// <param name="groupElement">The group element that acts as "key" in the query to the random oracle.</param>
+        /// <param name="invocationIndex">The index of the OT invocation this options belongs to.</param>
+        /// <param name="optionIndex">The index of the option.</param>
+        /// <returns>The masked option.</returns>
+        private byte[] MaskOption(byte[] option, BigInteger groupElement,  int invocationIndex, int optionIndex)
         {
             byte[] query = BufferBuilder.From(groupElement.ToByteArray()).With(invocationIndex).With(optionIndex).Create();
-            return _randomOracle.Mask(message, query);
+            return _randomOracle.Mask(option, query);
         }
     }
 }


### PR DESCRIPTION
Somewhat improved OT performance due to precomputation of exponentiations and increased interleaving of computation and communication. Increased performance in the corresponding unit test by ~16% (~60ms) on my machine (but I did not perform further, more extensive tests).

This comes at the cost of slightly more convoluted code (but it's not really bad, honestly), so I'm not sure if it meets the simple code base requirements.