### PR TITLE
Make OT 1-out-of-N

### DIFF
--- a/CompactMPC/BitArray.cs
+++ b/CompactMPC/BitArray.cs
@@ -132,5 +132,16 @@ namespace CompactMPC
             clone.Not();
             return clone;
         }
+
+        public static BitArray FromPairIndexArray(PairIndexArray array)
+        {
+            return new BitArray(array.ToBytes(), array.Length);
+        }
+
+        public PairIndexArray ToPairIndexArray()
+        {
+            return PairIndexArray.FromBytes(ToBytes(), Length);
+        }
+
     }
 }

--- a/CompactMPC/ObliviousTransfer/GeneralizedObliviousTransfer.cs
+++ b/CompactMPC/ObliviousTransfer/GeneralizedObliviousTransfer.cs
@@ -93,5 +93,21 @@ namespace CompactMPC.ObliviousTransfer
 
         protected abstract Task GeneralizedSendAsync(IMessageChannel channel, byte[][][] options, int numberOfOptions, int numberOfInvocations, int numberOfMessageBytes);
         protected abstract Task<byte[][]> GeneralizedReceiveAsync(IMessageChannel channel, int[] selectionIndices, int numberOfOptions, int numberOfInvocations, int numberOfMessageBytes);
+
+        public async Task SendAsync(IMessageChannel channel, Pair<byte[]>[] options, int numberOfInvocations, int numberOfMessageBytes)
+        {
+            await SendAsync(channel, options.Select(pair => pair.ToArray()).ToArray(), 2, numberOfInvocations, numberOfMessageBytes);
+        }
+
+        public async Task<byte[][]> ReceiveAsync(IMessageChannel channel, BitArray selectionIndices, int numberOfInvocations, int numberOfMessageBytes)
+        {
+            return await ReceiveAsync(channel, selectionIndices.ToPairIndexArray(), numberOfInvocations, numberOfMessageBytes);
+        }
+
+        public async Task<byte[][]> ReceiveAsync(IMessageChannel channel, PairIndexArray selectionIndices, int numberOfInvocations, int numberOfMessageBytes)
+        {
+            return await ReceiveAsync(channel, selectionIndices.ToArray(), 2, numberOfInvocations, numberOfMessageBytes);
+        }
+
     }
 }

--- a/CompactMPC/ObliviousTransfer/IGeneralizedObliviousTransfer.cs
+++ b/CompactMPC/ObliviousTransfer/IGeneralizedObliviousTransfer.cs
@@ -14,5 +14,8 @@ namespace CompactMPC.ObliviousTransfer
     {
         Task SendAsync(IMessageChannel channel, Quadruple<byte[]>[] options, int numberOfInvocations, int numberOfMessageBytes);
         Task<byte[][]> ReceiveAsync(IMessageChannel channel, QuadrupleIndexArray selectionIndices, int numberOfInvocations, int numberOfMessageBytes);
+
+        Task SendAsync(IMessageChannel channel, byte[][][] options, int numberOfOptions, int numberOfInvocations, int numberOfMessageBytes);
+        Task<byte[][]> ReceiveAsync(IMessageChannel channel, int[] selectionIndices, int numberOfOptions, int numberOfInvocations, int numberOfMessageBytes);
     }
 }

--- a/CompactMPC/ObliviousTransfer/IGeneralizedObliviousTransfer.cs
+++ b/CompactMPC/ObliviousTransfer/IGeneralizedObliviousTransfer.cs
@@ -12,6 +12,10 @@ namespace CompactMPC.ObliviousTransfer
 {
     public interface IGeneralizedObliviousTransfer
     {
+        Task SendAsync(IMessageChannel channel, Pair<byte[]>[] options, int numberOfInvocations, int numberOfMessageBytes);
+        Task<byte[][]> ReceiveAsync(IMessageChannel channel, BitArray selectionIndices, int numberOfInvocations, int numberOfMessageBytes);
+        Task<byte[][]> ReceiveAsync(IMessageChannel channel, PairIndexArray selectionIndices, int numberOfInvocations, int numberOfMessageBytes);
+
         Task SendAsync(IMessageChannel channel, Quadruple<byte[]>[] options, int numberOfInvocations, int numberOfMessageBytes);
         Task<byte[][]> ReceiveAsync(IMessageChannel channel, QuadrupleIndexArray selectionIndices, int numberOfInvocations, int numberOfMessageBytes);
 

--- a/CompactMPC/ObliviousTransfer/InsecureObliviousTransfer.cs
+++ b/CompactMPC/ObliviousTransfer/InsecureObliviousTransfer.cs
@@ -11,29 +11,29 @@ namespace CompactMPC.ObliviousTransfer
 {
     public class InsecureObliviousTransfer : GeneralizedObliviousTransfer
     {
-        protected override Task GeneralizedSendAsync(IMessageChannel channel, Quadruple<byte[]>[] options, int numberOfInvocations, int numberOfMessageBytes)
+        protected override Task GeneralizedSendAsync(IMessageChannel channel, byte[][][] options, int numberOfOptions, int numberOfInvocations, int numberOfMessageBytes)
         {
-            byte[] packedOptions = new byte[4 * numberOfInvocations * numberOfMessageBytes];
+            byte[] packedOptions = new byte[numberOfOptions * numberOfInvocations * numberOfMessageBytes];
             for (int i = 0; i < numberOfInvocations; ++i)
             {
-                for (int j = 0; j < 4; ++j)
-                    Buffer.BlockCopy(options[i][j], 0, packedOptions, (4 * i + j) * numberOfMessageBytes, numberOfMessageBytes);
+                for (int j = 0; j < numberOfOptions; ++j)
+                    Buffer.BlockCopy(options[i][j], 0, packedOptions, (numberOfOptions * i + j) * numberOfMessageBytes, numberOfMessageBytes);
             }
 
             return channel.WriteMessageAsync(packedOptions);
         }
 
-        protected override async Task<byte[][]> GeneralizedReceiveAsync(IMessageChannel channel, QuadrupleIndexArray selectionIndices, int numberOfInvocations, int numberOfMessageBytes)
+        protected override async Task<byte[][]> GeneralizedReceiveAsync(IMessageChannel channel, int[] selectionIndices, int numberOfOptions, int numberOfInvocations, int numberOfMessageBytes)
         {
             byte[] packedOptions = await channel.ReadMessageAsync();
-            if (packedOptions.Length != 4 * numberOfInvocations * numberOfMessageBytes)
+            if (packedOptions.Length != numberOfOptions * numberOfInvocations * numberOfMessageBytes)
                 throw new DesynchronizationException("Received incorrect number of options.");
 
             byte[][] selectedMessages = new byte[numberOfInvocations][];
             for (int i = 0; i < numberOfInvocations; ++i)
             {
                 selectedMessages[i] = new byte[numberOfMessageBytes];
-                Buffer.BlockCopy(packedOptions, (4 * i + selectionIndices[i]) * numberOfMessageBytes, selectedMessages[i], 0, numberOfMessageBytes);
+                Buffer.BlockCopy(packedOptions, (numberOfOptions * i + selectionIndices[i]) * numberOfMessageBytes, selectedMessages[i], 0, numberOfMessageBytes);
             }
 
             return selectedMessages;

--- a/CompactMPC/Pair.cs
+++ b/CompactMPC/Pair.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CompactMPC
+{
+    public class Pair<T> : IReadOnlyList<T>
+    {
+        public const int Length = 2;
+
+        private T[] _values;
+
+        public Pair()
+        {
+            _values = new T[Length];
+        }
+
+        public Pair(T v0, T v1 )
+        {
+            _values = new T[] { v0, v1 };
+        }
+
+        public Pair(T[] values)
+        {
+            if (values == null)
+                throw new ArgumentNullException(nameof(values));
+
+            if (values.Length != Length)
+                throw new ArgumentException("Source array must contain exactly two values.", nameof(values));
+
+            _values = (T[])values.Clone();
+        }
+        
+        public T this[int index]
+        {
+            get
+            {
+                if (index < 0 || index >= Length)
+                    throw new ArgumentOutOfRangeException(nameof(index));
+
+                return _values[index];
+            }
+            set
+            {
+                if (index < 0 || index >= Length)
+                    throw new ArgumentOutOfRangeException(nameof(index));
+
+                _values[index] = value;
+            }
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return ((IEnumerable<T>)_values).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return _values.GetEnumerator();
+        }
+
+        int IReadOnlyCollection<T>.Count
+        {
+            get
+            {
+                return Length;
+            }
+        }
+    }
+}

--- a/CompactMPC/PairIndexArray.cs
+++ b/CompactMPC/PairIndexArray.cs
@@ -7,23 +7,23 @@ using System.Threading.Tasks;
 
 namespace CompactMPC
 {
-    public class QuadrupleIndexArray : PackedArray<int>
+    public class PairIndexArray : PackedArray<int>
     {
-        private const int ElementsPerByte = 4;
-        private const int BitMask = 0b11;
+        private const int ElementsPerByte = 8;
+        private const int BitMask = 0b1;
 
-        public QuadrupleIndexArray(int numberOfElements)
+        public PairIndexArray(int numberOfElements)
             : base(RequiredBytes(numberOfElements), numberOfElements) { }
 
-        public QuadrupleIndexArray(int[] elements)
+        public PairIndexArray(int[] elements)
             : base(RequiredBytes(elements.Length), elements) { }
 
-        protected QuadrupleIndexArray(byte[] bytes, int numberOfElements)
+        protected PairIndexArray(byte[] bytes, int numberOfElements)
             : base(bytes, RequiredBytes(numberOfElements), numberOfElements) { }
 
-        public static QuadrupleIndexArray FromBytes(byte[] bytes, int numberOfElements)
+        public static PairIndexArray FromBytes(byte[] bytes, int numberOfElements)
         {
-            return new QuadrupleIndexArray(bytes, numberOfElements);
+            return new PairIndexArray(bytes, numberOfElements);
         }
 
         public static int RequiredBytes(int numberOfElements)
@@ -38,15 +38,15 @@ namespace CompactMPC
 
         protected override void WriteElement(int value, int index)
         {
-            if (value < 0 || value >= 4)
-                throw new ArgumentOutOfRangeException(nameof(value), "Quadruple index must be in the range from 0 to 3.");
+            if (value < 0 || value >= 2)
+                throw new ArgumentOutOfRangeException(nameof(value), "Pair index must be in the range from 0 to 1.");
 
             WriteBits((byte)value, index, ElementsPerByte, BitMask);
         }
 
-        public QuadrupleIndexArray Clone()
+        public PairIndexArray Clone()
         {
-            return new QuadrupleIndexArray(Buffer, Length);
+            return new PairIndexArray(Buffer, Length);
         }
     }
 }

--- a/UnitTests/ObliviousTransferTest.cs
+++ b/UnitTests/ObliviousTransferTest.cs
@@ -18,22 +18,24 @@ namespace CompactMPC.UnitTests
         private static readonly string[] TestOptions = { "Alicia", "Briann", "Charly", "Dennis" };
 
         [TestMethod]
-        public void TestNaorPinkasObliviousTransfer()
+        public void TestNaorPinkasObliviousTransfer1oo4()
         {
             Task.WhenAll(
-                Task.Factory.StartNew(RunObliviousTransferParty, TaskCreationOptions.LongRunning),
-                Task.Factory.StartNew(RunObliviousTransferParty, TaskCreationOptions.LongRunning)
+                Task.Factory.StartNew(RunObliviousTransferParty1oo4, TaskCreationOptions.LongRunning),
+                Task.Factory.StartNew(RunObliviousTransferParty1oo4, TaskCreationOptions.LongRunning)
             ).Wait();
         }
 
-        private void RunObliviousTransferParty()
+        private void RunObliviousTransferParty1oo4()
         {
-            Quadruple<byte[]>[] options = new Quadruple<byte[]>[3];
+            const int numberOfInvocations = 3;
+            const int numberOfOptions = 4;
+            Quadruple<byte[]>[] options = new Quadruple<byte[]>[numberOfInvocations];
             options = new Quadruple<byte[]>[]
             {
-                new Quadruple<byte[]>(TestOptions.Select(s => Encoding.ASCII.GetBytes(s)).ToArray()),
-                new Quadruple<byte[]>(TestOptions.Select(s => Encoding.ASCII.GetBytes(s.ToLower())).ToArray()),
-                new Quadruple<byte[]>(TestOptions.Select(s => Encoding.ASCII.GetBytes(s.ToUpper())).ToArray()),
+                new Quadruple<byte[]>(TestOptions.Take(numberOfOptions).Select(s => Encoding.ASCII.GetBytes(s)).ToArray()),
+                new Quadruple<byte[]>(TestOptions.Take(numberOfOptions).Select(s => Encoding.ASCII.GetBytes(s.ToLower())).ToArray()),
+                new Quadruple<byte[]>(TestOptions.Take(numberOfOptions).Select(s => Encoding.ASCII.GetBytes(s.ToUpper())).ToArray()),
             };
 
             using (CryptoContext cryptoContext = CryptoContext.CreateDefault())
@@ -47,17 +49,17 @@ namespace CompactMPC.UnitTests
                 {
                     if (session.LocalParty.Id == 0)
                     {
-                        obliviousTransfer.SendAsync(session.Channel, options, 3, 6).Wait();
+                        obliviousTransfer.SendAsync(session.Channel, options, numberOfInvocations, 6).Wait();
                     }
                     else
                     {
                         QuadrupleIndexArray indices = new QuadrupleIndexArray(new[] { 0, 3, 2 });
-                        byte[][] results = obliviousTransfer.ReceiveAsync(session.Channel, indices, 3, 6).Result;
+                        byte[][] results = obliviousTransfer.ReceiveAsync(session.Channel, indices, numberOfInvocations, 6).Result;
 
                         Assert.IsNotNull(results, "Result is null.");
-                        Assert.AreEqual(3, results.Length, "Result does not match the correct number of invocations.");
+                        Assert.AreEqual(numberOfInvocations, results.Length, "Result does not match the correct number of invocations.");
 
-                        for (int j = 0; j < 3; ++j)
+                        for (int j = 0; j < numberOfInvocations; ++j)
                         {
                             CollectionAssert.AreEqual(
                                 results[j],


### PR DESCRIPTION
Changed IGeneralizedObliviousTransfer interface (and its implementations) to allow for generic 1-out-of-N OT. Currently maintaining special overloads for 1oo4 and 1oo2, but we should consider splitting those in different interfaces.